### PR TITLE
Changed mutex_lock to mutex_unlock in L07 lecture

### DIFF
--- a/lectures/L07.tex
+++ b/lectures/L07.tex
@@ -56,7 +56,7 @@ void* consumer( void* arg ) {
     cindex = (cindex + 1) % BUFFER_SIZE;
     ++ctotal;
     sem_post( &spaces );
-    pthread_mutex_lock( &con_mutex );
+    pthread_mutex_unlock( &con_mutex );
   }
 }
 \end{lstlisting}
@@ -75,7 +75,7 @@ void* consumer( void* arg ) {
     cindex = (cindex + 1) % BUFFER_SIZE;
     ++ctotal;
     sem_post( &spaces );
-    pthread_mutex_lock( &con_mutex );
+    pthread_mutex_unlock( &con_mutex );
     consume( temp );
   }
 }


### PR DESCRIPTION
Doesn't make sense to double lock the mutex