### PR TITLE
Fix ABBA typo

### DIFF
--- a/lectures/L15-slides.tex
+++ b/lectures/L15-slides.tex
@@ -451,7 +451,7 @@ void spinlock_unlock(int* lock) {
 	\includegraphics[width=0.7\textwidth]{images/abba.jpeg}
 \end{center}
 
-The ABA problem is not any sort of acronym nor a reference to this: \url{https://www.youtube.com/watch? v=Sj_9CiNkkn4}
+The ABA problem is not any sort of acronym nor a reference to this: \url{https://www.youtube.com/watch?v=Sj_9CiNkkn4}
 
 
 \end{frame}


### PR DESCRIPTION
This fixes a typo in the link to the ABBA music video "Waterloo".