### PR TITLE
L20: Fix example syntax.

### DIFF
--- a/lectures/L20.tex
+++ b/lectures/L20.tex
@@ -334,17 +334,18 @@ virtual method calls with nonvirtual method calls.  Consider the
 following code:
   \begin{lstlisting}[language=C]
 class A {
+  public:
     virtual void m();
 };
 
 class B : public A {
-    virtual void m();
-}
+  public:
+    virtual void m() {}
+};
 
 int main(int argc, char *argv[]) {
-
     std::unique_ptr<A> t(new B);
-    t.m();
+    t->m();
 }
   \end{lstlisting}
 Devirtualization could eliminate vtable access; instead, we could just call B's {\tt m} method


### PR DESCRIPTION
This doesn't compile as is

- `m()` needs to be public.
- `m()` in `class B` wasn't implemented.
- `t.m()` should be `t->m()`
- Missing `;` after `class B`

Fixed based on: https://godbolt.org/z/NisNXj