### PR TITLE
Fix 2D grid reference typo in slides

### DIFF
--- a/lectures/L22-slides.tex
+++ b/lectures/L22-slides.tex
@@ -185,7 +185,7 @@
 
 
     \structure{Work-item}: the fundamental unit of work in OpenCL.\\
-    Stored in an {\it n}-dimensional grid (ND-Range); 2D above.\\[1em]
+    Stored in an {\it n}-dimensional grid (ND-Range); 2D on previous slide.\\[1em]
 
     OpenCL spawns a bunch of threads to handle work-items.\\
     When executing, the range is divided into {\bf work-groups}, which


### PR DESCRIPTION
"Above" works for the notebook, not for the slides, since it's on the previous slide.