### PR TITLE
Fix rust (2015) code typos in shared state section

### DIFF
--- a/lectures/L38.tex
+++ b/lectures/L38.tex
@@ -147,7 +147,7 @@ We'll need to talk about multiple ownership. But let's talk about mutexes first.
   fn main() {
     let m = Mutex::new(5); // mutex guards access to an i32
     {
-      let mut num = m.lock.unwrap();
+      let mut num = m.lock().unwrap();
       // unwrap: maybe some other thread panicked while holding lock;
       //         then we panick too.
       *num = 6; // "deref" the mutex (is actually a smart pointer)
@@ -176,7 +176,7 @@ will get rejected by the borrow checker. Instead, we have to use \emph{reference
       handles.push(handle);
     }
     for handle in handles {
-      handle.join.unwrap();
+      handle.join().unwrap();
     }
     println!("result: {}", *counter.lock().unwrap());
   }


### PR DESCRIPTION
* lock and join need ()