### PR TITLE
L13 synchronized function names in discussion with names in code listing

### DIFF
--- a/lectures/L13-slides.tex
+++ b/lectures/L13-slides.tex
@@ -328,10 +328,10 @@ fn do_work(x: i32, y: i32, threshold: i32) -> i32 {
 }
 \end{lstlisting}
 
-  Will we need to run {\tt secondLongCalculation}?
+  Will we need to run {\tt second\_long\_calculation}?
   \vfill  
   \begin{itemize}
-    \item<2> OK, so: could we execute {\tt longCalculation} and {\tt secondLongCalculation}
+    \item<2> OK, so: could we execute {\tt long\_calculation} and {\tt second\_long\_calculation}
       in parallel if we didn't have the conditional?
   \end{itemize}
   
@@ -365,8 +365,8 @@ fn do_work(x: i32, y: i32, threshold: i32) -> i32 {
   We do both the calculations in parallel and return the same result as before.
   
     \begin{itemize}
-    \item What are we assuming about {\tt longCalculation} and
-{\tt secondLongCalculation}?
+    \item What are we assuming about {\tt long\_calculation} and
+{\tt second\_long\_calculation}?
   \end{itemize}
 
 
@@ -399,11 +399,11 @@ fn do_work(x: i32, y: i32, threshold: i32) -> i32 {
 \begin{frame}
 \frametitle{Check Assumptions}
   
-  $T_1$: time to run {\tt longCalculation}.
+  $T_1$: time to run {\tt long\_calculation}.
 
-  $T_2$: time to run {\tt secondLongCalculation}.
+  $T_2$: time to run {\tt second\_long\_calculation}.
 
-  $p$: probability that {\tt secondLongCalculation} executes.\\[1em]
+  $p$: probability that {\tt second\_long\_calculation} executes.\\[1em]
 
   In the normal case we have:
     \[T_{\mbox{\scriptsize normal}} = T_1 + pT_2.\]
@@ -435,7 +435,7 @@ fn do_other_work(x: i32, y: i32) -> i32 {
   Now we have a true dependency; can't use speculative~execution.\\[1em]
 
   But: if the value is predictable, we can execute
-      {\tt secondLongCalculation} using the predicted value.\\[1em]
+      {\tt second\_long\_calculation} using the predicted value.\\[1em]
 
   This is \structure{value speculation}.
   
@@ -473,11 +473,11 @@ fn do_other_work(x: i32, y: i32, last_value: i32) -> i32 {
   \frametitle{Estimating Impact of Value Speculation}
 
   
-  $T_1$: time to run {\tt longCalculatuion}.
+  $T_1$: time to run {\tt long\_calculation}.
 
-  $T_2$: time to run {\tt secondLongCalculation}.
+  $T_2$: time to run {\tt second\_long\_calculation}.
 
-  $p$: probability that {\tt secondLongCalculation} executes again.
+  $p$: probability that {\tt second\_long\_calculation} executes again.
 
   $S$: synchronization overhead.\\[1em]
 
@@ -501,11 +501,11 @@ fn do_other_work(x: i32, y: i32, last_value: i32) -> i32 {
   Required conditions for safety:
 
   \begin{itemize}
-    \item {\tt longCalculation} and {\tt secondLongCalculation} must not call
+    \item {\tt long\_calculation} and {\tt second\_long\_calculation} must not call
       each other.
-    \item {\tt secondLongCalculation} must not depend on
-      any values set or modified by {\tt longCalculation}.
-    \item The return value of {\tt longCalculation} must be deterministic.
+    \item {\tt second\_long\_calculation} must not depend on
+      any values set or modified by {\tt long\_calculation}.
+    \item The return value of {\tt long\_calculation} must be deterministic.
   \end{itemize}
 
   General warning: Consider \structure{side effects} of function calls.

--- a/lectures/L13.tex
+++ b/lectures/L13.tex
@@ -200,9 +200,9 @@ fn do_work(x: i32, y: i32, threshold: i32) -> i32 {
 }
 \end{lstlisting}
 Without more information, you don't know whether you'll have to execute
-{\tt secondLongCalculation()} or not; it depends on the return value of
-{\tt longCalculation()}.  Fortunately, the arguments to {\tt secondLongCalculation()} do not
-depend on {\tt longCalculation()}, so we can call it at any point. 
+{\tt second\_long\_calculation()} or not; it depends on the return value of
+{\tt long\_calculation()}.  Fortunately, the arguments to {\tt second\_long\_calculation()} do not
+depend on {\tt long\_calculation()}, so we can call it at any point. 
 Here's one way to speculatively thread the work:
 
 \begin{lstlisting}[language=Rust]
@@ -243,8 +243,8 @@ fn do_work(x: i32, y: i32, threshold: i32) -> i32 {
 
 We can model the above code by estimating the probability $p$ that
 the second calculation needs to run, the time $T_1$ that it takes
-to run {\tt longCalculation}, the time $T_2$ that it takes to run
-{\tt secondLongCalculation}, and synchronization overhead $S$.
+to run {\tt long\_calculation}, the time $T_2$ that it takes to run
+{\tt second\_long\_calculation}, and synchronization overhead $S$.
 Then the original code takes time
 \[ T = T_1 + p T_2, \]
 while the speculative code takes time
@@ -269,7 +269,7 @@ fn do_other_work(x: i32, y: i32) -> i32 {
 \end{lstlisting}
 
 If the result of {\tt value} is predictable, then we can speculatively
-execute {\tt secondLongCalculation} based on the predicted value.
+execute {\tt second\_long\_calculation} based on the predicted value.
 (Most values in programs are indeed predictable). If 90\% of customers are using the standard billing plan, you might assume that that's correct in your calculations, and then change that later if it turns out you are wrong. Or you might have a software cache where you keep the latest state so you don't have to go to the database to check a value that changes rarely. 
 
 \begin{lstlisting}[language=Rust]
@@ -299,11 +299,11 @@ where $S$ is still the synchronization overhead, and $p$ is the probability that
 \subsection*{When can we speculate?}
 Speculation isn't always safe. We need the following conditions:
   \begin{itemize}
-    \item {\tt longCalculation} and {\tt secondLongCalculation} must not call
+    \item {\tt long\_calculation} and {\tt second\_long\_calculation} must not call
       each other.
-    \item {\tt secondLongCalculation} must not depend on
-      any values set or modified by {\tt longCalculation}.
-    \item The return value of {\tt longCalculation} must be deterministic.
+    \item {\tt second\_long\_calculation} must not depend on
+      any values set or modified by {\tt long\_calculation}.
+    \item The return value of {\tt long\_calculation} must be deterministic.
   \end{itemize}
 
 As a general warning: Consider the \emph{side effects} of function calls. Oh, let's talk about side effects. Why not. They have a big impact on parallelism. Side effects are problematic, but why? For one thing they're kind of unpredictable (why does calling this function result in unexpected changes elsewhere?!). Side effects are changes in state that do not depend on the function input. Calling a function or expression has a side effect if it has some visible effect on the outside world. Some things necessarily have side effects, like printing to the console. Others are side effects which may be avoidable if we can help it, like modifying a global variable. As we've seen, Rust discourages those kinds of problems but doesn't forbid them: we can still have atomic types shared that would represent some sort of global state.


### PR DESCRIPTION
Lecture 13 used long_calculation() and second_long_calculation() in code listings but referred to them as longCalculation and secondLongCalculation in the discussion. I changed everything to use snake case for consistency and readability.