### PR TITLE
Correct lock compare and swap expected return value

### DIFF
--- a/lectures/L12.tex
+++ b/lectures/L12.tex
@@ -124,6 +124,7 @@ fn main() {
     // ... Other stuff happens
 
     while my_lock.compare_and_swap(false, true, Ordering::SeqCst) == true {
+        // The lock was `true`, someone else has the lock, so try again
         spin_loop_hint();
     }
     // Inside critical section

--- a/lectures/L12.tex
+++ b/lectures/L12.tex
@@ -123,7 +123,7 @@ fn main() {
     let my_lock = AtomicBool::new(false);
     // ... Other stuff happens
 
-    while my_lock.compare_and_swap(false, true, Ordering::SeqCst) == false {
+    while my_lock.compare_and_swap(false, true, Ordering::SeqCst) == true {
         spin_loop_hint();
     }
     // Inside critical section


### PR DESCRIPTION
From the follow up to [this Piazza question](https://piazza.com/class/kiz072yjgnk57a?cid=118)

Fixes the example using spinlock `compare_and_swap` to continue trying to lock if the old_value of the lock is `true`. Old value of `true` means locking was unsuccessful.

Fixes #59 