### PR TITLE
Make fn var argument mutable typo fix

### DIFF
--- a/lectures/L18.tex
+++ b/lectures/L18.tex
@@ -82,7 +82,7 @@ below example, we need to compute {\tt c + d} only once.
 
 
 \begin{lstlisting}[language=Rust]
-    pub fn add(c:i32, d: i32, y:i32, z:i32) -> (i32, i32, i32) {
+    pub fn add(c:i32, d: i32, mut y:i32, mut z:i32) -> (i32, i32, i32) {
         let a = (c + d) * y;
         let b = (c + d) * z;
         let w = 3; let x = f(); let y = x;


### PR DESCRIPTION
As mentioned in [Lecture 18 @ 12:50](https://youtu.be/iHVUVyVZBK0?t=770) the y value (and I'm assuming the z value?) need to be mutable `mut` in the function signature.