### PR TITLE
Fix compare and swap in L12 slides

### DIFF
--- a/lectures/L12-slides.tex
+++ b/lectures/L12-slides.tex
@@ -451,7 +451,8 @@ fn main() {
     let my_lock = AtomicBool::new(false);
     // ... Other stuff happens
 
-    while my_lock.compare_and_swap(false, true, Ordering::SeqCst) == false {
+    while my_lock.compare_and_swap(false, true, Ordering::SeqCst) == true {
+	// The lock was `true`, someone else had the lock, so try again
         spin_loop_hint();
     }
     // Inside critical section


### PR DESCRIPTION
Follow up to #61 

I realize now that I needed to update the `-slides.tex` file as well... so this PR adds that fix.