### PR TITLE
L22+L23: Add bounds checks to nbody CUDA Code

### DIFF
--- a/lectures/L22.tex
+++ b/lectures/L22.tex
@@ -168,6 +168,9 @@ __device__ void body_body_interaction(float4 point1, float4 point2, float3 *acce
 }
 
 extern "C" __global__ void calculate_forces(const float4* positions, float3* accelerations, int num_points) {
+    if (blockIdx.x >= num_points) {
+        return;
+    }
     float4 current = positions[blockIdx.x];
     float3 acc = accelerations[blockIdx.x];
 

--- a/lectures/L23-slides.tex
+++ b/lectures/L23-slides.tex
@@ -257,6 +257,9 @@ I did have to add a +1 to the number of blocks, because 100~000 does not divide 
 \begin{lstlisting}[language=C++]
 extern "C" __global__ void calculate_forces(const float4* positions, float3* accelerations, int num_points) {
     int idx = threadIdx.x + blockIdx.x * blockDim.x;
+    if (idx >= num_points) {
+        return;
+    }
     float4 current = positions[idx];
     float3 acc = accelerations[idx];
 

--- a/lectures/L23.tex
+++ b/lectures/L23.tex
@@ -259,6 +259,9 @@ I did have to add a +1 to the number of blocks, because 100~000 does not divide 
 \begin{lstlisting}[language=C++]
 extern "C" __global__ void calculate_forces(const float4* positions, float3* accelerations, int num_points) {
     int idx = threadIdx.x + blockIdx.x * blockDim.x;
+    if (idx >= num_points) {
+        return;
+    }
     float4 current = positions[idx];
     float3 acc = accelerations[idx];
 

--- a/lectures/live-coding/L23/nbody-cuda-grid/resources/nbody.cu
+++ b/lectures/live-coding/L23/nbody-cuda-grid/resources/nbody.cu
@@ -20,6 +20,9 @@ __device__ void body_body_interaction(float4 point1, float4 point2, float3 *acce
 
 extern "C" __global__ void calculate_forces(const float4* positions, float3* accelerations, int num_points) {
     int idx = threadIdx.x + blockIdx.x * blockDim.x;
+    if (idx >= num_points) {
+        return;
+    }
     float4 current = positions[idx];
     float3 acc = accelerations[idx];
 

--- a/lectures/live-coding/L23/nbody-cuda/resources/nbody.cu
+++ b/lectures/live-coding/L23/nbody-cuda/resources/nbody.cu
@@ -19,6 +19,9 @@ __device__ void body_body_interaction(float4 point1, float4 point2, float3 *acce
 }
 
 extern "C" __global__ void calculate_forces(const float4* positions, float3* accelerations, int num_points) {
+    if (blockIdx.x >= num_points) {
+        return;
+    }
     float4 current = positions[blockIdx.x];
     float3 acc = accelerations[blockIdx.x];
 


### PR DESCRIPTION
- Add bounds checks to the nbody example to prevent reads/writes at invalid indices
- Patched fix in the code and lecture material
- Link to Piazza discussion: https://piazza.com/class/kiz072yjgnk57a?cid=292