### PR TITLE
consistent byte ordering for VByte

### DIFF
--- a/lectures/L17-slides.tex
+++ b/lectures/L17-slides.tex
@@ -436,7 +436,7 @@ VByte works like this:
 \item $x$ between $2^7$ and $2^{14}-1$ (e.g. $1729 = 0b110 11000001$):\\
 \hspace*{1em}                   $1xxx xxxx/0xxx xxxx$ (e.g. $1100 0001/0000 1101$);\\
 \item $x$ between $2^{14}$ and $2^{21}-1$: \\
-\hspace*{1em}$0xxx xxxx/1xxx xxxx/1xxx xxxx$;
+\hspace*{1em}$1xxx xxxx/1xxx xxxx/0xxx xxxx$;
 \item etc.
 \end{itemize}
 


### PR DESCRIPTION
The byte ordering should be consistent between the examples. In the example for x between 2^7 and 2^14-1), the 0 control bit is on the rightmost byte, but the example for x between 2^14 and 2^21-1 had the 0 control bit on the leftmost byte.

This PR gives the 0 control bit to the rightmost byte for both examples.