### PR TITLE
fix nested loop semantics

### DIFF
--- a/lectures/L18-slides.tex
+++ b/lectures/L18-slides.tex
@@ -323,7 +323,7 @@ coincide with the ordering of array elements in memory.
 pub fn mul(mut a: [[i32; 8]; 4], c: i32) {
   for i in 0..7 {
      for j in 0..3 {
-       a[i][j] = a[i][j] * c;
+       a[j][i] = a[j][i] * c;
      }
   }
 }

--- a/lectures/L18.tex
+++ b/lectures/L18.tex
@@ -197,7 +197,7 @@ For instance:
 pub fn mul(mut a: [[i32; 8]; 4], c: i32) {
     for i in 0..7 {
         for j in 0..3 {
-            a[i][j] = a[i][j] * c;
+            a[j][i] = a[j][i] * c;
         }
     }
 }


### PR DESCRIPTION
The original example for loop interchange does not preserve the semantic behaviour of the pre-transformation loop.
The transformation should only change the order in which the program iterates over the indices - it should not change how the indices are used.
In the original example, we have `a[i][j]` -> `a[j][i]`, which is wrong.
One of the pre- or post-transformation loops should be changed so that both versions of the code have `a[j][i]` or `a[i][j]`.

Since `j` is the inner loop variable in the pre-transformation code and we're suggesting that Rust is row-major, the pre-transformation code should be changed to `a[j][i]` to demonstrate that the loop interchange transformation reorders indices to match the ordering of array elements.