### PR TITLE
Adjust details in L17 regarding slices.

### DIFF
--- a/lectures/L17-slides.tex
+++ b/lectures/L17-slides.tex
@@ -320,9 +320,9 @@ coincide with the ordering of array elements in memory.
 \vspace*{-1em}
 \begin{minipage}{.39\textwidth}
   \begin{lstlisting}[language=Rust]
-pub fn mul(mut a: [[i32; 8]; 4], c: i32) {
-  for i in 0..7 {
-     for j in 0..3 {
+pub fn mul(a: &mut [[i32; 8]; 4], c: i32) {
+  for i in 0..8 {
+     for j in 0..4 {
        a[j][i] = a[j][i] * c;
      }
   }
@@ -330,9 +330,9 @@ pub fn mul(mut a: [[i32; 8]; 4], c: i32) {
   \end{lstlisting}
   \end{minipage} $\hspace*{2em} \Longrightarrow \hspace*{2em}$ \begin{minipage}{.4\textwidth}
   \begin{lstlisting}[language=Rust]
-pub fn mul(mut a: [[i32; 8]; 4], c: i32) {
-  for j in 0..3 {
-    for i in 0..7 {
+pub fn mul(a: &mut [[i32; 8]; 4], c: i32) {
+  for j in 0..4 {
+    for i in 0..8 {
       a[j][i] = a[j][i] * c;
     }
   }
@@ -340,9 +340,7 @@ pub fn mul(mut a: [[i32; 8]; 4], c: i32) {
   \end{lstlisting}
   \end{minipage}
   \end{center}
-  A stackoverflow answer suggests that Rust is row-major
-  (a[1][1] is beside a[1][2]) but that this is not
-  guaranteed.
+  Rust is row-major but swapping the order may affect performance on some CPUs.
   
 \end{frame}
 

--- a/lectures/L17.tex
+++ b/lectures/L17.tex
@@ -194,9 +194,9 @@ For instance:
 \vspace*{-1em}
 \begin{minipage}{.39\textwidth}
   \begin{lstlisting}[language=Rust]
-pub fn mul(mut a: [[i32; 8]; 4], c: i32) {
-    for i in 0..7 {
-        for j in 0..3 {
+pub fn mul(a: &mut [[i32; 8]; 4], c: i32) {
+    for i in 0..8 {
+        for j in 0..4 {
             a[j][i] = a[j][i] * c;
         }
     }
@@ -204,9 +204,9 @@ pub fn mul(mut a: [[i32; 8]; 4], c: i32) {
   \end{lstlisting}
   \end{minipage} $\hspace*{2em} \Longrightarrow \hspace*{2em}$ \begin{minipage}{.4\textwidth}
   \begin{lstlisting}[language=Rust]
-pub fn mul(mut a: [[i32; 8]; 4], c: i32) {
-    for j in 0..3 {
-        for i in 0..7 {
+pub fn mul(a: &mut [[i32; 8]; 4], c: i32) {
+    for j in 0..4 {
+        for i in 0..8 {
             a[j][i] = a[j][i] * c;
         }
     }
@@ -214,11 +214,9 @@ pub fn mul(mut a: [[i32; 8]; 4], c: i32) {
   \end{lstlisting}
   \end{minipage}
   \end{center}
-  A stackoverflow answer suggests that Rust is row-major
-  (a[1][1] is beside a[1][2]) but that this is not
-  guaranteed: {\scriptsize \url{https://stackoverflow.com/questions/37316336/is-rust-multi-dimensional-array-row-major-and-tightly-packed}}. OpenGL, on the other hand, is supposedly column-major.
+  Rust is row-major (a[1][1] is beside a[1][2]) as items in a slice are laid out an equal distance from each other: {\scriptsize \url{https://doc.rust-lang.org/std/primitive.slice.html}}. OpenGL, on the other hand, is supposedly column-major.
 
-Strangely enough, sometimes you want to do things the column-major way even though it's ``wrong''. If your two dimensional array is of an appropriate size then by intentionally hitting things in the ``wrong'' order, you'll trigger all your page faults up front and load all your pages into cache and then you can go wild. This was suggested as a way to make matrix multiplication faster for a sufficiently large matrix\ldots
+Strangely enough, sometimes you want to do things the column-major way even though it's ``wrong''. If your two dimensional array is of an appropriate size then by intentionally hitting things in the ``wrong'' order, you'll trigger all your page faults up front and load all your pages into cache and then you can go wild. This was suggested as a way to make matrix multiplication faster for a sufficiently large matrix: {\scriptsize \url{https://www.intel.com/content/www/us/en/developer/articles/technical/loop-optimizations-where-blocks-are-required.html?wapkw=loop%20optimization}}\ldots
 
 \paragraph{Loop fusion.} Here, we transform
 \begin{center}

--- a/lectures/notebook.tex
+++ b/lectures/notebook.tex
@@ -5045,9 +5045,9 @@ For instance:
 \vspace*{-1em}
 \begin{minipage}{.39\textwidth}
   \begin{lstlisting}[language=Rust]
-pub fn mul(mut a: [[i32; 8]; 4], c: i32) {
-    for i in 0..7 {
-        for j in 0..3 {
+pub fn mul(a: &mut [[i32; 8]; 4], c: i32) {
+    for i in 0..8 {
+        for j in 0..4 {
             a[j][i] = a[j][i] * c;
         }
     }
@@ -5055,9 +5055,9 @@ pub fn mul(mut a: [[i32; 8]; 4], c: i32) {
   \end{lstlisting}
   \end{minipage} $\hspace*{2em} \Longrightarrow \hspace*{2em}$ \begin{minipage}{.4\textwidth}
   \begin{lstlisting}[language=Rust]
-pub fn mul(mut a: [[i32; 8]; 4], c: i32) {
-    for j in 0..3 {
-        for i in 0..7 {
+pub fn mul(a: &mut [[i32; 8]; 4], c: i32) {
+    for j in 0..4 {
+        for i in 0..8 {
             a[j][i] = a[j][i] * c;
         }
     }
@@ -5065,11 +5065,9 @@ pub fn mul(mut a: [[i32; 8]; 4], c: i32) {
   \end{lstlisting}
   \end{minipage}
   \end{center}
-  A stackoverflow answer suggests that Rust is row-major
-  (a[1][1] is beside a[1][2]) but that this is not
-  guaranteed: {\scriptsize \url{https://stackoverflow.com/questions/37316336/is-rust-multi-dimensional-array-row-major-and-tightly-packed}}. OpenGL, on the other hand, is supposedly column-major.
+  Rust is row-major (a[1][1] is beside a[1][2]) as items in a slice are laid out an equal distance from each other: {\scriptsize \url{https://doc.rust-lang.org/std/primitive.slice.html}}. OpenGL, on the other hand, is supposedly column-major.
 
-Strangely enough, sometimes you want to do things the column-major way even though it's ``wrong''. If your two dimensional array is of an appropriate size then by intentionally hitting things in the ``wrong'' order, you'll trigger all your page faults up front and load all your pages into cache and then you can go wild. This was suggested as a way to make matrix multiplication faster for a sufficiently large matrix\ldots
+Strangely enough, sometimes you want to do things the column-major way even though it's ``wrong''. If your two dimensional array is of an appropriate size then by intentionally hitting things in the ``wrong'' order, you'll trigger all your page faults up front and load all your pages into cache and then you can go wild. This was suggested as a way to make matrix multiplication faster for a sufficiently large matrix: {\scriptsize \url{https://www.intel.com/content/www/us/en/developer/articles/technical/loop-optimizations-where-blocks-are-required.html?wapkw=loop%20optimization}}\ldots
 
 \paragraph{Loop fusion.} Here, we transform
 \begin{center}


### PR DESCRIPTION
This does four things:

- The code example used the wrong indices, this fixes it.
- The code actually gets compiled to nothing because it has no side-effects, this uses an `&mut` reference instead.
- Rust slices are defined to have a [contiguous layout in memory](https://doc.rust-lang.org/std/primitive.slice.html) and hence when you're able to observe it, the compiler guarantees the layout is as such (in this case because it's going through a reference, it'll always be laid out as described unless it's inlined).
- I dug up a reference I read a few years back about specifically this topic, and added it (although I'm not sure if we're permitted to reference it).