### PR TITLE
Fix typo in L03 slides and notes

### DIFF
--- a/lectures/L03-slides.tex
+++ b/lectures/L03-slides.tex
@@ -504,7 +504,7 @@ To implement the trait, implement the functions.
 
 \begin{lstlisting}[language=Rust]
 pub trait FinalGrade {
-	fun final_grade(&self) -> f32;
+	fn final_grade(&self) -> f32;
 }
 
 impl FinalGrade for Enrolled_Student {

--- a/lectures/L03.tex
+++ b/lectures/L03.tex
@@ -210,7 +210,7 @@ Okay, we have to take a detour here onto the subject of Traits. As the previous 
 
 \begin{lstlisting}[language=Rust]
 pub trait FinalGrade {
-	fun final_grade(&self) -> f32;
+	fn final_grade(&self) -> f32;
 }
 
 impl FinalGrade for Enrolled_Student {


### PR DESCRIPTION
I believe that this is a typo in the code block describing traits in the Lecture 3 slides and notes.