### PR TITLE
Fix CUDA sum launch config L22

### DIFF
--- a/lectures/L22-slides.tex
+++ b/lectures/L22-slides.tex
@@ -64,7 +64,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // This kernel adds each element in `in_x` and `in_y` and writes the result into `out`.
     unsafe {
         // Launch the kernel with one block of one thread, no dynamic shared memory on `stream`.
-        let result = launch!(module.sum<<<1, 1, 0, stream>>>(
+        let result = launch!(module.sum<<<(1, 1, 1), (10, 1, 1), 0, stream>>>(
             in_x.as_device_ptr(),
             in_y.as_device_ptr(),
             out_1.as_device_ptr(),


### PR DESCRIPTION
* fix launch configuration from host code in L22 for starter sum example
* current configuration launches a single thread so will only compute the sum `out[0] = in_x[0] + in_y[0]`. 
* the correct configuration is on the linked example [here](https://github.com/bheisler/RustaCUDA/blob/master/examples/launch.rs#L40)
* I guess there needs to be more explanation of the launch config with the corrected version though