### PR TITLE
replace broken Discord blog hyperlink

### DIFF
--- a/lectures/459.bib
+++ b/lectures/459.bib
@@ -990,7 +990,7 @@ keywords = "Data compression, Indexing, Vectorization, SIMD instructions, Algori
   author = {Jesse Howarth},
   title = {Why {Discord} is switching from {Go} to {Rust}},
   year = {2020},
-  url = {https://blog.discord.com/why-discord-is-switching-from-go-to-rust-a190bbca2b1f},
+  url = {https://discord.com/blog/why-discord-is-switching-from-go-to-rust},
   note = {Online; accessed 2020-09-12}
 }
 


### PR DESCRIPTION
L02 mentions a Discord blog post about switching from Go to Rust. It appears that some point, Discord moved their blog URL and makes the current URL simply redirects to the homepage of the blog.

This PR updates the URL to point to the new location (https://discord.com/blog/why-discord-is-switching-from-go-to-rust).